### PR TITLE
Simplify installation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -35,6 +35,16 @@ bl_info = {
 
 import bpy
 
+
+# ensure dependencies exist
+try:
+    import svglib, svgpathtools
+except ImportError:
+    import subprocess
+    print("Installing dependencies...")
+    subprocess.check_call([bpy.app.binary_path_python, '-m', 'pip', 'install', 'svglib', 'svgpathtools'])
+
+
 from . import auto_load
 
 auto_load.init()

--- a/stickers.py
+++ b/stickers.py
@@ -125,16 +125,7 @@ class Stickers:
             return UVVertex(M.Vector((v.real, v.imag)))
 
     def load_geometry(self, filename):
-        path_to_stickers_mac = "/Applications/Blender.app/Contents/Resources/2.82/scripts/addons/foldmold/Stickers/"
-        path_to_stickers_win = "C:\Program Files\\Blender Foundation\\Blender 2.81\\2.81\\scripts\\addons\\foldmold\\Stickers\\"
-
-        if sys.platform.startswith('win32'):
-            path_to_stickers = path_to_stickers_win
-        elif sys.platform.startswith('darwin'):
-            path_to_stickers = path_to_stickers_mac
-        else:
-            raise ValueError('Please add path for system other than windows or osx')
-
+        path_to_stickers = os_path.join(os_path.dirname(__file__), 'Stickers')
         return self.svg2uv(os_path.join(path_to_stickers, filename))
 
 


### PR DESCRIPTION
A quick set of changes which should make installation basically painless for end-users (no messing with pip commands).

Tested to work with Blender 2.83 on macOS; other configurations haven't been tested (in particular, I don't have a Windows machine handy).